### PR TITLE
hfest-repo: fix for Linux; fix audit errors

### DIFF
--- a/hfest-repo.rb
+++ b/hfest-repo.rb
@@ -1,12 +1,11 @@
 class HfestRepo < Formula
-  desc "hfest-repo is a tool that adds the hacktoberfest topic to every public repository associated with a user or a GitHub org. It can also create the invalid, spam and hacktoberfest-accepted labels in your repos."
+  desc "Tool that adds the hacktoberfest topic and labels to GitHub public repositories"
   homepage "https://github.com/Hacktoberfest/hacktoberfest-repo-topic-apply"
+  url "https://github.com/Hacktoberfest/hacktoberfest-repo-topic-apply/releases/download/v0.0.10/hfest-repo_0.0.10_darwin_amd64.tar.gz"
   version "0.0.10"
+  sha256 "e88da7d784ae2a1b02aeeb0ed210cd4bf1d80e13fbd486df4725956014fd399a"
 
-  if OS.mac?
-    url "https://github.com/Hacktoberfest/hacktoberfest-repo-topic-apply/releases/download/v0.0.10/hfest-repo_0.0.10_darwin_amd64.tar.gz"
-    sha256 "e88da7d784ae2a1b02aeeb0ed210cd4bf1d80e13fbd486df4725956014fd399a"
-  end
+  depends_on :macos
 
   def install
     bin.install "hfest-repo"


### PR DESCRIPTION
When one taps this repository on Linux, they get a bunch of errors:
```
==> Tapping k1low/tap
Cloning into '/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/k1low/homebrew-tap'...
(…)
Error: Invalid formula: /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/k1low/homebrew-tap/hfest-repo.rb
formulae require at least a URL
Error: Invalid formula: /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/k1low/homebrew-tap/connected.rb
formulae require at least a URL
Error: Invalid formula: /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/k1low/homebrew-tap/tbls.rb
formulae require at least a URL
Error: Invalid formula: /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/k1low/homebrew-tap/brewfile-desc.rb
formulae require at least a URL
Tapped 42 formulae (54 files, 416.4KB).
Error: formulae require at least a URL
Do not report this issue until you've run `brew update` and tried again.
(…)
```

This is because those formulas use `if OS.mac? url "..."` instead of `depends_on :macos`. I fixed only `hfest-repo` because the other ones are generated by GoReleaser and should be fixed in their own repositories (or this is a GoReleaser bug?). I also fixed the audit warning regarding the length and format of the description. You can run such audit with `brew audit --strict k1low/tap/hfest-repo`.