### PR TITLE
Update sha256 of imgcat

### DIFF
--- a/imgcat.rb
+++ b/imgcat.rb
@@ -4,7 +4,7 @@ class Imgcat < Formula
   version '1.0.0'
 
   url 'https://iterm2.com/utilities/imgcat'
-  sha256 'b8fd783db29dbdd8a84beabbc251544dcc26bafad3b20c9ff32db7e8c7cd2869'
+  sha256 '49945beb679baaccfc089d2f3e57c0aedeb4f6bf4c7c53ca261ad664018edab4'
 
   def install
     bin.install 'imgcat'


### PR DESCRIPTION
## About

- Currently, we can not install imgcat from `k1low/tap/imgcat`
    - So I want to update the sha256 checksum of `imgcat`

```
❯ brew install k1low/tap/imgcat
==> Fetching k1low/tap/imgcat
==> Downloading https://iterm2.com/utilities/imgcat
####################################################################################################################################################################################################################################################### 100.0%
Error: imgcat: SHA256 mismatch
Expected: b8fd783db29dbdd8a84beabbc251544dcc26bafad3b20c9ff32db7e8c7cd2869
  Actual: 49945beb679baaccfc089d2f3e57c0aedeb4f6bf4c7c53ca261ad664018edab4
    File: /Users/suzuki/Library/Caches/Homebrew/downloads/4e8c44ae142841ac49eb54ad7943a78f4947df852be36ba2e52ea669336139f6--imgcat
To retry an incomplete download, remove the file above.
```