### PR TITLE
fix: repair formulae broken on Linux under Homebrew 6.0.0 (#7)

### DIFF
--- a/Casks/tiley.rb
+++ b/Casks/tiley.rb
@@ -13,7 +13,7 @@ cask "tiley" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sonoma"
+  depends_on macos: :sonoma
 
   app "Tiley.app"
 

--- a/brewfile-desc.rb
+++ b/brewfile-desc.rb
@@ -9,22 +9,19 @@ class BrewfileDesc < Formula
   license "MIT"
   depends_on :macos
 
-  on_macos do
-    if Hardware::CPU.arm?
-      url "https://github.com/k1LoW/brewfile-desc/releases/download/v0.1.1/brewfile-desc_v0.1.1_darwin_arm64.zip"
-      sha256 "5bd52af1d234a657bf00547c7c50291b072394e36e09ea9f58ffa507c8acaf75"
+  # brewfile-desc ships macOS-only release artifacts, so the URL is selected by
+  # CPU (which is evaluated on any OS) instead of inside `on_macos`. Wrapping it
+  # in `on_macos` would leave no URL defined when the formula is loaded on Linux,
+  # and recent Homebrew rejects that with "formula requires at least a URL".
+  if Hardware::CPU.arm?
+    url "https://github.com/k1LoW/brewfile-desc/releases/download/v0.1.1/brewfile-desc_v0.1.1_darwin_arm64.zip"
+    sha256 "5bd52af1d234a657bf00547c7c50291b072394e36e09ea9f58ffa507c8acaf75"
+  else
+    url "https://github.com/k1LoW/brewfile-desc/releases/download/v0.1.1/brewfile-desc_v0.1.1_darwin_amd64.zip"
+    sha256 "1c4261b408601459a9b26f3d0f103b25bfb83d370df37ae9badea0fdb7a83c0f"
+  end
 
-      def install
-        bin.install 'brewfile-desc'
-      end
-    end
-    if Hardware::CPU.intel?
-      url "https://github.com/k1LoW/brewfile-desc/releases/download/v0.1.1/brewfile-desc_v0.1.1_darwin_amd64.zip"
-      sha256 "1c4261b408601459a9b26f3d0f103b25bfb83d370df37ae9badea0fdb7a83c0f"
-
-      def install
-        bin.install 'brewfile-desc'
-      end
-    end
+  def install
+    bin.install "brewfile-desc"
   end
 end

--- a/connected.rb
+++ b/connected.rb
@@ -4,10 +4,26 @@ class Connected < Formula
   homepage "https://github.com/k1LoW/connected"
   version "0.4.1"
 
-  if OS.mac?
-    url "https://github.com/k1LoW/connected/releases/download/v0.4.1/connected_v0.4.1_darwin_amd64.zip"
-    sha256 "438fb17761934ea85c5de5dbbd12bf1ff0b771820ff274d7a9efeed8b54bebe6"
-  elsif OS.linux?
+  on_macos do
+    if Hardware::CPU.arm?
+      url "https://github.com/k1LoW/connected/releases/download/v0.4.1/connected_v0.4.1_darwin_arm64.zip"
+      sha256 "6fea64346c2bc2a6c5ba2a80f5e69478c137e6b9ce3c06045f85161743e43380"
+    end
+    if Hardware::CPU.intel?
+      url "https://github.com/k1LoW/connected/releases/download/v0.4.1/connected_v0.4.1_darwin_amd64.zip"
+      sha256 "438fb17761934ea85c5de5dbbd12bf1ff0b771820ff274d7a9efeed8b54bebe6"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+      url "https://github.com/k1LoW/connected/releases/download/v0.4.1/connected_v0.4.1_linux_arm64.tar.gz"
+      sha256 "b9f86610d224454305ada218ad2cda6f80c271d106f052493a5139544e7e207c"
+    end
+    if Hardware::CPU.intel?
+      url "https://github.com/k1LoW/connected/releases/download/v0.4.1/connected_v0.4.1_linux_amd64.tar.gz"
+      sha256 "e6f1aa50c0ce95dc9bf650c3813687001f29610a3fd006cc73c0c84e5808c286"
+    end
   end
 
   def install

--- a/ebk.rb
+++ b/ebk.rb
@@ -28,6 +28,14 @@ class Ebk < Formula
   end
 
   on_linux do
+    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+      url "https://github.com/k1LoW/ebk/releases/download/v0.2.5/ebk_v0.2.5_linux_arm64.tar.gz"
+      sha256 "1527c688b33d446093ef47bb729d946e89aaa8baf462c68f85c0a721cd7e17cf"
+
+      def install
+        bin.install "ebk"
+      end
+    end
     if Hardware::CPU.intel?
       url "https://github.com/k1LoW/ebk/releases/download/v0.2.5/ebk_v0.2.5_linux_amd64.tar.gz"
       sha256 "2405f67cc09bad42d759d4c6aea860169adbd516736fc43d256219c93243e121"

--- a/gh-star-history.rb
+++ b/gh-star-history.rb
@@ -28,6 +28,14 @@ class GhStarHistory < Formula
   end
 
   on_linux do
+    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+      url "https://github.com/k1LoW/gh-star-history/releases/download/v0.2.6/gh-star-history_v0.2.6_linux_arm64.tar.gz"
+      sha256 "caf02006d49203417264a739ff3f96d40b14899efc24a93e4a01e659ab4ecfff"
+
+      def install
+        bin.install "gh-star-history"
+      end
+    end
     if Hardware::CPU.intel?
       url "https://github.com/k1LoW/gh-star-history/releases/download/v0.2.6/gh-star-history_v0.2.6_linux_amd64.tar.gz"
       sha256 "c5caf9e930e0a4c99dc89a353e564d1e44338c430bdb1549fa7ec7a5e81f8a90"

--- a/ghput.rb
+++ b/ghput.rb
@@ -7,7 +7,6 @@ class Ghput < Formula
   homepage "https://github.com/k1LoW/ghput"
   version "0.14.6"
   license "MIT"
-  depends_on :macos
 
   on_macos do
     if Hardware::CPU.arm?
@@ -25,6 +24,33 @@ class Ghput < Formula
     if Hardware::CPU.intel?
       url "https://github.com/k1LoW/ghput/releases/download/v0.14.6/ghput_v0.14.6_darwin_amd64.zip"
       sha256 "7469c96acd0a2defe7437a6fd72a29c8738435acec9e79fe5e7555289e4690d8"
+
+      def install
+        system './ghput', 'completion', 'bash', '--out', 'ghput.bash'
+        system './ghput', 'completion', 'zsh', '--out', 'ghput.zsh'
+        bin.install 'ghput'
+        bash_completion.install 'ghput.bash' => 'ghput'
+        zsh_completion.install 'ghput.zsh' => '_ghput'
+      end
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+      url "https://github.com/k1LoW/ghput/releases/download/v0.14.6/ghput_v0.14.6_linux_arm64.tar.gz"
+      sha256 "481d4c098389639b7cb5e12e923d29514c48cef704295e9939189aae0bbf1c31"
+
+      def install
+        system './ghput', 'completion', 'bash', '--out', 'ghput.bash'
+        system './ghput', 'completion', 'zsh', '--out', 'ghput.zsh'
+        bin.install 'ghput'
+        bash_completion.install 'ghput.bash' => 'ghput'
+        zsh_completion.install 'ghput.zsh' => '_ghput'
+      end
+    end
+    if Hardware::CPU.intel?
+      url "https://github.com/k1LoW/ghput/releases/download/v0.14.6/ghput_v0.14.6_linux_amd64.tar.gz"
+      sha256 "d9f6356a597448ed7d2657303682234e05e02b959cc273549c1084dfd32da158"
 
       def install
         system './ghput', 'completion', 'bash', '--out', 'ghput.bash'

--- a/hfest-repo.rb
+++ b/hfest-repo.rb
@@ -3,9 +3,23 @@ class HfestRepo < Formula
   homepage "https://github.com/Hacktoberfest/hacktoberfest-repo-topic-apply"
   version "0.1.1"
 
-  if OS.mac?
-    url "https://github.com/Hacktoberfest/hacktoberfest-repo-topic-apply/releases/download/v0.1.1/hfest-repo_0.1.1_darwin_amd64.tar.gz"
-    sha256 "dcf2f05692152e1f941b2335a29fa7ed0220e626b32890abd5249155bdf58ed1"
+  on_macos do
+    # Only an amd64 darwin artifact is published; Apple Silicon runs it via Rosetta.
+    if Hardware::CPU.arm? || Hardware::CPU.intel?
+      url "https://github.com/Hacktoberfest/hacktoberfest-repo-topic-apply/releases/download/v0.1.1/hfest-repo_0.1.1_darwin_amd64.tar.gz"
+      sha256 "dcf2f05692152e1f941b2335a29fa7ed0220e626b32890abd5249155bdf58ed1"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+      url "https://github.com/Hacktoberfest/hacktoberfest-repo-topic-apply/releases/download/v0.1.1/hfest-repo_0.1.1_linux_arm64.tar.gz"
+      sha256 "88eca0345bc33686384376ce3c60edb25b1bd5140ab0f1f7944f1e32ab1f244d"
+    end
+    if Hardware::CPU.intel?
+      url "https://github.com/Hacktoberfest/hacktoberfest-repo-topic-apply/releases/download/v0.1.1/hfest-repo_0.1.1_linux_amd64.tar.gz"
+      sha256 "147aacac0287d4b56f5244ac3f8d08d6384768e3c6a288e9277de171085be6ec"
+    end
   end
 
   def install

--- a/ndiag.rb
+++ b/ndiag.rb
@@ -36,6 +36,18 @@ class Ndiag < Formula
   end
 
   on_linux do
+    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+      url "https://github.com/k1LoW/ndiag/releases/download/v0.15.2/ndiag_v0.15.2_linux_arm64.tar.gz"
+      sha256 "23e4e4344862acdcf6e0d54a5df26e9148429a73482ffe0af2fcc39d171d4526"
+
+      def install
+        system './ndiag', 'completion', 'bash', '--out', 'ndiag.bash'
+        system './ndiag', 'completion', 'zsh', '--out', 'ndiag.zsh'
+        bin.install 'ndiag'
+        bash_completion.install 'ndiag.bash' => 'ndiag'
+        zsh_completion.install 'ndiag.zsh' => '_ndiag'
+      end
+    end
     if Hardware::CPU.intel?
       url "https://github.com/k1LoW/ndiag/releases/download/v0.15.2/ndiag_v0.15.2_linux_amd64.tar.gz"
       sha256 "636bddd278987d567fe1baf794eaf6f5e05a18fcdbc8782638bb99cd81ea4700"

--- a/octocov-runn-coverage.rb
+++ b/octocov-runn-coverage.rb
@@ -1,5 +1,5 @@
 class OctocovRunnCoverage < Formula
-  desc 'Generate octocov custom metrics JSON from the output of 'runn coverage'.'
+  desc "Generate octocov custom metrics JSON from the output of 'runn coverage'."
   version '0.1.11'
   homepage 'https://github.com/k1LoW/octocov-runn-coverage'
 

--- a/repin.rb
+++ b/repin.rb
@@ -28,6 +28,14 @@ class Repin < Formula
   end
 
   on_linux do
+    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+      url "https://github.com/k1LoW/repin/releases/download/v0.4.1/repin_v0.4.1_linux_arm64.tar.gz"
+      sha256 "11e7a119b8319d0033d1f20384812962b020a04a1ced6c2fcf54fa0442154ed3"
+
+      def install
+        bin.install 'repin'
+      end
+    end
     if Hardware::CPU.intel?
       url "https://github.com/k1LoW/repin/releases/download/v0.4.1/repin_v0.4.1_linux_amd64.tar.gz"
       sha256 "836cbd9cc574b71a7fe1c3cec8963333e9c22b6dd80c8b3654bcb3d19edbe2d4"

--- a/tsocks.rb
+++ b/tsocks.rb
@@ -6,7 +6,7 @@ class Tsocks < Formula
   homepage 'http://github.com/pc/tsocks'
   head 'https://github.com/pc/tsocks.git'
 
-  depends_on 'autoconf' => :build if MacOS::Xcode.version.to_f >= 4.3
+  depends_on 'autoconf' => :build
 
   def install
     system 'autoconf', '-v'

--- a/vo.rb
+++ b/vo.rb
@@ -6,29 +6,29 @@ class Vo < Formula
   homepage "https://github.com/k1LoW/vo"
   version "0.4.0"
   license "MIT"
+  # vo only ships an arm64 macOS artifact. The URL is defined at the top level
+  # (rather than inside `on_macos`) so the formula still resolves a URL when it
+  # is loaded on Linux; recent Homebrew rejects a URL-less formula with "formula
+  # requires at least a URL". Installation is restricted by the `depends_on`s.
+  url "https://github.com/k1LoW/vo/releases/download/v#{version}/vo_v#{version}_darwin_arm64.tar.gz"
+  sha256 "fd86d941b64a52f5b8d55a644c02eb72c4b0f81c10f4ce07561e4c7c7dfac202"
 
   livecheck do
     url :url
     strategy :github_latest
   end
 
+  depends_on arch: :arm64
   depends_on macos: :tahoe
 
-  on_macos do
-    if Hardware::CPU.arm?
-      url "https://github.com/k1LoW/vo/releases/download/v#{version}/vo_v#{version}_darwin_arm64.tar.gz"
-      sha256 "fd86d941b64a52f5b8d55a644c02eb72c4b0f81c10f4ce07561e4c7c7dfac202"
-
-      def install
-        bin.install "vo"
-        # The downloaded tarball inherits `com.apple.quarantine` from the macOS
-        # network stack (LaunchServices marks archive downloads regardless of
-        # the HTTP client used), and `tar -x` carries the attribute over to the
-        # extracted binary. Gatekeeper would then refuse to launch the
-        # ad-hoc-signed binary on first run. Strip the attribute explicitly so
-        # the installed binary works without `xattr -cr` from the user.
-        system "/usr/bin/xattr", "-cr", bin/"vo"
-      end
-    end
+  def install
+    bin.install "vo"
+    # The downloaded tarball inherits `com.apple.quarantine` from the macOS
+    # network stack (LaunchServices marks archive downloads regardless of
+    # the HTTP client used), and `tar -x` carries the attribute over to the
+    # extracted binary. Gatekeeper would then refuse to launch the
+    # ad-hoc-signed binary on first run. Strip the attribute explicitly so
+    # the installed binary works without `xattr -cr` from the user.
+    system "/usr/bin/xattr", "-cr", bin/"vo"
   end
 end

--- a/vo.rb
+++ b/vo.rb
@@ -18,8 +18,16 @@ class Vo < Formula
     strategy :github_latest
   end
 
+  # A versioned `depends_on macos:` only sets the macOS version floor; on Linux
+  # it is treated as satisfied, so the bare `:macos` is what actually keeps this
+  # macOS-only formula from installing on Linux. The version floor itself lives
+  # in `on_macos` because pairing it with the bare `:macos` at the top level is
+  # deprecated.
+  depends_on :macos
   depends_on arch: :arm64
-  depends_on macos: :tahoe
+  on_macos do
+    depends_on macos: :tahoe
+  end
 
   def install
     bin.install "vo"


### PR DESCRIPTION
## Summary

Closes #7.

Homebrew 6.0.0 turned several previously-tolerated formula DSL patterns from deprecation warnings into hard errors, and now imports every formula in the tap on Linux as well. That surfaced a set of latent macOS-centric mistakes, breaking `brew update` / tap operations for Linux users.

This PR fixes every formula that failed to load, verified with `brew readall k1low/tap` (which evaluates each formula across all OS/arch combinations, including `arm64_linux`).

## Changes

### Reported in #7 (broke on the reporter's amd64 Linux)

- **octocov-runn-coverage**: unescaped single quotes inside a single-quoted `desc` caused a Ruby syntax error → use a double-quoted string.
- **tsocks**: `MacOS::Xcode.version` was evaluated at load time, but the `MacOS` constant does not exist on Linux → depend on `autoconf` unconditionally (always needed for the source build).
- **ghput, connected, hfest-repo**: macOS-only URLs even though Linux artifacts exist, so no URL on Linux → add the missing `on_linux` blocks.
- **brewfile-desc, vo**: genuinely macOS-only, but wrapping the URL in `on_macos` left no URL when loaded on Linux ("formula requires at least a URL") → define the URL outside the OS conditional and keep the macOS restriction via `depends_on`.
- **tiley** (cask): deprecated `depends_on macos: ">= :sonoma"` string comparison → symbol form `depends_on macos: :sonoma`.

### Also found while auditing the tap (broke only on arm64 Linux)

- **ebk, gh-star-history, ndiag, repin**: `on_linux` only handled `intel?`, so no URL on arm64 Linux → add the arm64 branch (upstream already ships `linux_arm64` artifacts).

## Out of scope

`dirmap`, `ghdag`, `oshka`, `pr-bullet`, `pr-revert` also fail to load on arm64 Linux for the same reason, but upstream does not publish `linux_arm64` artifacts at the pinned versions, so they are left untouched here rather than restricting them artificially.

## Test plan

- [x] `ruby -c` on every changed file
- [x] `brew style` (no structural offenses introduced)
- [x] `brew readall k1low/tap` with the changes applied — none of the 11 fixed formulae error on any platform (only the 5 out-of-scope formulae above remain, on arm64 Linux only)