### PR TITLE
feat: add capsomnia cask

### DIFF
--- a/Casks/capsomnia.rb
+++ b/Casks/capsomnia.rb
@@ -1,0 +1,33 @@
+cask "capsomnia" do
+  version "1.0.0"
+  sha256 "a8bfd0803df9a1be7120bcada99777c0f12389c7f515add3b44b4e0ce4d37ac4"
+
+  url "https://github.com/fuji-mak/Capsomnia/releases/download/v#{version}/Capsomnia-#{version}.pkg"
+  name "Capsomnia"
+  desc "Turns Caps Lock into a physical keep-awake switch for closed-lid MacBook work"
+  homepage "https://github.com/fuji-mak/Capsomnia"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: :sonoma
+  depends_on arch: :arm64
+
+  pkg "Capsomnia-#{version}.pkg"
+
+  uninstall launchctl: "com.github.fuji-mak.capsomnia",
+            pkgutil:   "com.github.fuji-mak.capsomnia.pkg",
+            delete:    [
+              "/etc/sudoers.d/capsomnia",
+              "/Library/LaunchAgents/com.github.fuji-mak.capsomnia.plist",
+              "/Library/PrivilegedHelperTools/capsomnia-pmset",
+            ]
+
+  zap trash: [
+    "~/Library/Caches/com.github.fuji-mak.capsomnia",
+    "~/Library/Preferences/com.github.fuji-mak.capsomnia.plist",
+    "~/Library/Saved Application State/com.github.fuji-mak.capsomnia.savedState",
+  ]
+end


### PR DESCRIPTION
## Summary

Add a cask for [Capsomnia](https://github.com/fuji-mak/Capsomnia), a small macOS utility that turns Caps Lock into a physical keep-awake switch for closed-lid MacBook work. Upstream distributes it as a signed and notarized `.pkg`, so this is a `pkg`-based cask rather than an app-in-zip cask like `tiley`.

## Changes

- New `Casks/capsomnia.rb` pinned to `v1.0.0` (sha256 `a8bfd0803df9a1be7120bcada99777c0f12389c7f515add3b44b4e0ce4d37ac4`).
- `depends_on macos: :sonoma` + `depends_on arch: :arm64` to match upstream's stated requirement (macOS 14+ on Apple silicon).
- `livecheck` via `:github_latest` for future version bumps.

## Notes on the uninstall stanza

The pkg's `postinstall` installs artifacts well outside the `.app` bundle:

- `/Applications/Capsomnia.app` (handled by `pkgutil` forget + normal cask cleanup)
- `/Library/PrivilegedHelperTools/capsomnia-pmset`
- `/Library/LaunchAgents/com.github.fuji-mak.capsomnia.plist`
- `/etc/sudoers.d/capsomnia` — a NOPASSWD rule scoped to three fixed `capsomnia-pmset` subcommands (`on`, `off`, `display-sleep`) for the console user

`pkgutil forget` alone will not delete these, and leaving `/etc/sudoers.d/capsomnia` behind after uninstall would be surprising, so all three paths are enumerated in `uninstall delete:`. `launchctl` unloads the agent before the files are removed.

`zap trash:` covers per-user preference / cache / saved-state files under `~/Library/*`.

## Test plan

- [x] `brew style k1low/tap/capsomnia` (no offenses)
- [x] `brew audit --cask --new --online k1low/tap/capsomnia` (only the personal-tap-irrelevant "GitHub repository not notable enough" warning remains)
- [ ] `brew install --cask k1low/tap/capsomnia` on macOS 14+ / arm64
- [ ] `brew uninstall --cask k1low/tap/capsomnia` leaves no residual `/etc/sudoers.d/capsomnia`, LaunchAgent, or helper binary